### PR TITLE
Added Metadata to Slot & CG in DSSCollection

### DIFF
--- a/dss-collection-nft/contracts/DSSCollection.cdc
+++ b/dss-collection-nft/contracts/DSSCollection.cdc
@@ -26,7 +26,8 @@ pub contract DSSCollection: NonFungibleToken {
         name: String,
         description: String,
         productName: String,
-        endTime: UFix64?
+        endTime: UFix64?,
+        metadata: {String: String}
     )
     pub event CollectionGroupClosed(id: UInt64)
     pub event ItemCreatedInSlot(
@@ -43,7 +44,7 @@ pub contract DSSCollection: NonFungibleToken {
         logicalOperator: String,
         required: Bool,
         typeName: Type,
-        batchKey: String
+        metadata: {String: String}
     )
     pub event CollectionNFTMinted(
         id: UInt64,
@@ -101,6 +102,7 @@ pub contract DSSCollection: NonFungibleToken {
         pub let required: Bool
         pub let typeName: Type // (Type<A.f8d6e0586b0a20c7.ExampleNFT.NFT>()...)
         pub var items: [Item]
+        pub let metadata: {String: String}
 
         init (id: UInt64) {
             if let slot = &DSSCollection.slotByID[id] as &DSSCollection.Slot? {
@@ -110,6 +112,7 @@ pub contract DSSCollection: NonFungibleToken {
                 self.required = slot.required
                 self.typeName = slot.typeName
                 self.items = slot.items
+                self.metadata = slot.metadata
             } else {
                 panic("Slot does not exist")
             }
@@ -125,7 +128,7 @@ pub contract DSSCollection: NonFungibleToken {
         pub let required: Bool
         pub let typeName: Type // (Type<A.f8d6e0586b0a20c7.ExampleNFT.NFT>())
         pub var items: [Item]
-        pub var batchKey: String // off-chain key for slot
+        pub let metadata: {String: String}
 
         // Create item in slot
         //
@@ -167,7 +170,7 @@ pub contract DSSCollection: NonFungibleToken {
             logicalOperator: String,
             required: Bool,
             typeName: Type,
-            batchKey: String
+            metadata: {String: String}
         ) {
             pre {
                 DSSCollection.CollectionGroupData(
@@ -183,7 +186,7 @@ pub contract DSSCollection: NonFungibleToken {
             self.logicalOperator = logicalOperator
             self.required = required
             self.typeName = typeName
-            self.batchKey = batchKey
+            self.metadata = metadata
             self.items = []
 
             emit SlotCreated(
@@ -192,7 +195,7 @@ pub contract DSSCollection: NonFungibleToken {
                 logicalOperator: self.logicalOperator,
                 required: self.required,
                 typeName: self.typeName,
-                batchKey: self.batchKey
+                metadata: self.metadata
             )
         }
     }
@@ -206,6 +209,7 @@ pub contract DSSCollection: NonFungibleToken {
         pub let productName: String
         pub let active: Bool
         pub let endTime: UFix64?
+        pub let metadata: {String: String}
 
         init (id: UInt64) {
             if let collectionGroup = &DSSCollection.collectionGroupByID[id] as &DSSCollection.CollectionGroup? {
@@ -215,6 +219,7 @@ pub contract DSSCollection: NonFungibleToken {
                 self.productName = collectionGroup.productName
                 self.active = collectionGroup.active
                 self.endTime = collectionGroup.endTime
+                self.metadata = collectionGroup.metadata
             } else {
                 panic("CollectionGroup does not exist")
             }
@@ -231,6 +236,7 @@ pub contract DSSCollection: NonFungibleToken {
         pub var active: Bool
         pub let endTime: UFix64?
         pub var numMinted: UInt64
+        pub let metadata: {String: String}
 
         // Close this collection group
         //
@@ -273,7 +279,8 @@ pub contract DSSCollection: NonFungibleToken {
             name: String,
             description: String,
             productName: String,
-            endTime: UFix64?
+            endTime: UFix64?,
+            metadata: {String: String}
         ) {
             pre {
                 DSSCollection.validateTimeBound(
@@ -287,13 +294,15 @@ pub contract DSSCollection: NonFungibleToken {
             self.active = true
             self.endTime = endTime
             self.numMinted = 0 as UInt64
+            self.metadata = metadata
 
             emit CollectionGroupCreated(
                 id: self.id,
                 name: self.name,
                 description: self.description,
                 productName: self.productName,
-                endTime: self.endTime
+                endTime: self.endTime,
+                metadata: self.metadata
             )
         }
     }
@@ -583,13 +592,15 @@ pub contract DSSCollection: NonFungibleToken {
             name: String,
             description: String,
             productName: String,
-            endTime: UFix64?
+            endTime: UFix64?,
+            metadata: {String: String}
         ): UInt64 {
             let collectionGroup <- create DSSCollection.CollectionGroup(
                 name: name,
                 description: description,
                 productName: productName,
-                endTime: endTime
+                endTime: endTime,
+                metadata: metadata
             )
             let collectionGroupID = collectionGroup.id
             DSSCollection.collectionGroupByID[collectionGroup.id] <-! collectionGroup
@@ -614,14 +625,14 @@ pub contract DSSCollection: NonFungibleToken {
             logicalOperator: String,
             required: Bool,
             typeName: Type,
-            batchKey: String
+            metadata: {String: String}
         ): UInt64 {
             let slot <- create DSSCollection.Slot(
                 collectionGroupID: collectionGroupID,
                 logicalOperator: logicalOperator,
                 required: required,
                 typeName: typeName,
-                batchKey: batchKey
+                metadata: metadata
             )
             let slotID = slot.id
             DSSCollection.slotByID[slot.id] <-! slot

--- a/dss-collection-nft/contracts/DSSCollection.cdc
+++ b/dss-collection-nft/contracts/DSSCollection.cdc
@@ -42,7 +42,8 @@ pub contract DSSCollection: NonFungibleToken {
         collectionGroupID: UInt64,
         logicalOperator: String,
         required: Bool,
-        typeName: Type
+        typeName: Type,
+        batchKey: String
     )
     pub event CollectionNFTMinted(
         id: UInt64,
@@ -124,6 +125,7 @@ pub contract DSSCollection: NonFungibleToken {
         pub let required: Bool
         pub let typeName: Type // (Type<A.f8d6e0586b0a20c7.ExampleNFT.NFT>())
         pub var items: [Item]
+        pub var batchKey: String // off-chain key for slot
 
         // Create item in slot
         //
@@ -164,7 +166,8 @@ pub contract DSSCollection: NonFungibleToken {
             collectionGroupID: UInt64,
             logicalOperator: String,
             required: Bool,
-            typeName: Type
+            typeName: Type,
+            batchKey: String
         ) {
             pre {
                 DSSCollection.CollectionGroupData(
@@ -180,6 +183,7 @@ pub contract DSSCollection: NonFungibleToken {
             self.logicalOperator = logicalOperator
             self.required = required
             self.typeName = typeName
+            self.batchKey = batchKey
             self.items = []
 
             emit SlotCreated(
@@ -187,7 +191,8 @@ pub contract DSSCollection: NonFungibleToken {
                 collectionGroupID: self.collectionGroupID,
                 logicalOperator: self.logicalOperator,
                 required: self.required,
-                typeName: self.typeName
+                typeName: self.typeName,
+                batchKey: self.batchKey
             )
         }
     }
@@ -608,13 +613,15 @@ pub contract DSSCollection: NonFungibleToken {
             collectionGroupID: UInt64,
             logicalOperator: String,
             required: Bool,
-            typeName: Type
+            typeName: Type,
+            batchKey: String
         ): UInt64 {
             let slot <- create DSSCollection.Slot(
                 collectionGroupID: collectionGroupID,
                 logicalOperator: logicalOperator,
                 required: required,
-                typeName: typeName
+                typeName: typeName,
+                batchKey: batchKey
             )
             let slotID = slot.id
             DSSCollection.slotByID[slot.id] <-! slot

--- a/dss-collection-nft/lib/go/test/dss_collection_test.go
+++ b/dss-collection-nft/lib/go/test/dss_collection_test.go
@@ -192,6 +192,7 @@ func testCreateSlot(
 		"NBA Top Shot",
 	)
 	required := true
+	batchKey := "123-345"
 
 	slotID := createSlot(
 		t,
@@ -201,6 +202,7 @@ func testCreateSlot(
 		collectionGroupID,
 		logicalOperator,
 		required,
+		batchKey,
 	)
 
 	if !shouldRevert {
@@ -246,6 +248,7 @@ func testCreateItemInSlot(
 		"All Stars",
 		"NBA Top Shot",
 	)
+	batchKey := "123-456"
 
 	slotID := createSlot(
 		t,
@@ -255,6 +258,7 @@ func testCreateItemInSlot(
 		collectionGroupID,
 		"OR",
 		true,
+		batchKey,
 	)
 
 	comparator := "="

--- a/dss-collection-nft/lib/go/test/dss_collection_test.go
+++ b/dss-collection-nft/lib/go/test/dss_collection_test.go
@@ -65,6 +65,7 @@ func testCreateCollectionGroup(
 		collectionGroupName,
 		"All Stars",
 		productName,
+		map[string]string{"key": "META"},
 	)
 
 	if !shouldRevert {
@@ -106,6 +107,7 @@ func testCreateTimeBoundCollectionGroup(
 		"All Stars Description",
 		"NBA Top Shot",
 		2368296360_00000000,
+		map[string]string{"key": "META"},
 	)
 	if !shouldRevert {
 		collectionGroup := getCollectionGroupData(t, b, contracts, collectionGroupId)
@@ -143,6 +145,7 @@ func testCloseCollectionGroup(
 		"Top Shot All Stars",
 		"All Stars",
 		"NBA Top Shot",
+		map[string]string{"key": "META"},
 	)
 
 	closeCollectionGroup(
@@ -190,9 +193,9 @@ func testCreateSlot(
 		"NBA All Stars",
 		"All Stars",
 		"NBA Top Shot",
+		map[string]string{"key": "META"},
 	)
 	required := true
-	batchKey := "123-345"
 
 	slotID := createSlot(
 		t,
@@ -202,7 +205,7 @@ func testCreateSlot(
 		collectionGroupID,
 		logicalOperator,
 		required,
-		batchKey,
+		map[string]string{"key": "META"},
 	)
 
 	if !shouldRevert {
@@ -247,8 +250,8 @@ func testCreateItemInSlot(
 		"NBA All Stars",
 		"All Stars",
 		"NBA Top Shot",
+		map[string]string{"key": "META"},
 	)
-	batchKey := "123-456"
 
 	slotID := createSlot(
 		t,
@@ -258,7 +261,7 @@ func testCreateItemInSlot(
 		collectionGroupID,
 		"OR",
 		true,
-		batchKey,
+		map[string]string{"key": "META"},
 	)
 
 	comparator := "="
@@ -313,6 +316,7 @@ func testMintNFT(
 		collectionGroupName,
 		"All Stars",
 		"NBA Top Shot",
+		map[string]string{"key": "META"},
 	)
 
 	closeCollectionGroup(

--- a/dss-collection-nft/lib/go/test/test.go
+++ b/dss-collection-nft/lib/go/test/test.go
@@ -322,3 +322,15 @@ func getNFTData(
 
 	return parseNFTProperties(result)
 }
+
+func metadataDict(dict map[string]string) cadence.Dictionary {
+	pairs := []cadence.KeyValuePair{}
+
+	for key, value := range dict {
+		k, _ := cadence.NewString(key)
+		v, _ := cadence.NewString(value)
+		pairs = append(pairs, cadence.KeyValuePair{Key: k, Value: v})
+	}
+
+	return cadence.NewDictionary(pairs)
+}

--- a/dss-collection-nft/lib/go/test/transactions.go
+++ b/dss-collection-nft/lib/go/test/transactions.go
@@ -142,6 +142,7 @@ func createSlot(
 	collectionGroupID uint64,
 	logicalOperator string,
 	required bool,
+	batchKey string,
 ) uint64 {
 	tx := flow.NewTransaction().
 		SetScript(createSlotTransaction(contracts)).
@@ -152,6 +153,7 @@ func createSlot(
 	tx.AddArgument(cadence.UInt64(collectionGroupID))
 	tx.AddArgument(cadence.String(logicalOperator))
 	tx.AddArgument(cadence.Bool(required))
+	tx.AddArgument(cadence.String(batchKey))
 
 	signer, _ := b.ServiceKey().Signer()
 	txResult := signAndSubmit(

--- a/dss-collection-nft/lib/go/test/transactions.go
+++ b/dss-collection-nft/lib/go/test/transactions.go
@@ -53,6 +53,7 @@ func createCollectionGroup(
 	collectionGroupName string,
 	collectionGroupDescription string,
 	productName string,
+	metadata map[string]string,
 ) uint64 {
 	tx := flow.NewTransaction().
 		SetScript(createCollectionGroupTransaction(contracts)).
@@ -63,6 +64,7 @@ func createCollectionGroup(
 	tx.AddArgument(cadence.String(collectionGroupName))
 	tx.AddArgument(cadence.String(collectionGroupDescription))
 	tx.AddArgument(cadence.String(productName))
+	tx.AddArgument(metadataDict(metadata))
 
 	signer, _ := b.ServiceKey().Signer()
 	txResult := signAndSubmit(
@@ -85,6 +87,7 @@ func createTimeBoundCollectionGroup(
 	collectionGroupDescription string,
 	productName string,
 	endTime int,
+	metadata map[string]string,
 ) uint64 {
 	tx := flow.NewTransaction().
 		SetScript(createTimeBoundCollectionGroupTransaction(contracts)).
@@ -96,6 +99,7 @@ func createTimeBoundCollectionGroup(
 	tx.AddArgument(cadence.String(collectionGroupDescription))
 	tx.AddArgument(cadence.String(productName))
 	tx.AddArgument(cadence.UFix64(endTime))
+	tx.AddArgument(metadataDict(metadata))
 
 	signer, _ := b.ServiceKey().Signer()
 	txResult := signAndSubmit(
@@ -142,7 +146,7 @@ func createSlot(
 	collectionGroupID uint64,
 	logicalOperator string,
 	required bool,
-	batchKey string,
+	metadata map[string]string,
 ) uint64 {
 	tx := flow.NewTransaction().
 		SetScript(createSlotTransaction(contracts)).
@@ -153,7 +157,7 @@ func createSlot(
 	tx.AddArgument(cadence.UInt64(collectionGroupID))
 	tx.AddArgument(cadence.String(logicalOperator))
 	tx.AddArgument(cadence.Bool(required))
-	tx.AddArgument(cadence.String(batchKey))
+	tx.AddArgument(metadataDict(metadata))
 
 	signer, _ := b.ServiceKey().Signer()
 	txResult := signAndSubmit(

--- a/dss-collection-nft/lib/go/test/types.go
+++ b/dss-collection-nft/lib/go/test/types.go
@@ -10,6 +10,7 @@ type CollectionGroupData struct {
 	Description string
 	ProductName string
 	Active      bool
+	Metadata    map[string]string
 }
 
 type SlotData struct {
@@ -19,6 +20,7 @@ type SlotData struct {
 	Required          bool
 	TypeName          cadence.Type
 	Items             []Item
+	Metadata          map[string]string
 }
 
 type Item struct {
@@ -50,6 +52,7 @@ func parseCollectionGroupData(value cadence.Value) CollectionGroupData {
 		fields[2].ToGoValue().(string),
 		fields[3].ToGoValue().(string),
 		fields[4].ToGoValue().(bool),
+		cadenceStringDictToGo(fields[6].(cadence.Dictionary)),
 	}
 }
 
@@ -67,6 +70,7 @@ func parseSlotData(value cadence.Value) SlotData {
 		fields[3].ToGoValue().(bool),
 		fields[4].Type(),
 		items,
+		cadenceStringDictToGo(fields[6].(cadence.Dictionary)),
 	}
 	return slotData
 }

--- a/dss-collection-nft/transactions/admin/create_collection_group.cdc
+++ b/dss-collection-nft/transactions/admin/create_collection_group.cdc
@@ -1,7 +1,7 @@
 import DSSCollection from "../../contracts/DSSCollection.cdc"
 
 
-transaction(name: String, description: String, productName: String) {
+transaction(name: String, description: String, productName: String, metadata: {String: String}) {
     let admin: &DSSCollection.Admin
 
     prepare(signer: AuthAccount) {
@@ -14,7 +14,8 @@ transaction(name: String, description: String, productName: String) {
             name: name,
             description: description,
             productName: productName,
-            endTime: nil
+            endTime: nil,
+            metadata: metadata
         )
 
         log("====================================")

--- a/dss-collection-nft/transactions/admin/create_collection_group_time_bound.cdc
+++ b/dss-collection-nft/transactions/admin/create_collection_group_time_bound.cdc
@@ -1,6 +1,6 @@
 import DSSCollection from "../../contracts/DSSCollection.cdc"
 
-transaction(name: String, description: String, productName: String, endTime: UFix64?) {
+transaction(name: String, description: String, productName: String, endTime: UFix64?, metadata: {String: String}) {
     let admin: &DSSCollection.Admin
 
     prepare(signer: AuthAccount) {
@@ -13,7 +13,8 @@ transaction(name: String, description: String, productName: String, endTime: UFi
             name: name,
             description: description,
             productName: productName,
-            endTime: endTime
+            endTime: endTime,
+            metadata: metadata
         )
 
         log("====================================")

--- a/dss-collection-nft/transactions/admin/create_slot.cdc
+++ b/dss-collection-nft/transactions/admin/create_slot.cdc
@@ -2,7 +2,7 @@ import DSSCollection from "../../contracts/DSSCollection.cdc"
 import ExampleNFT from 0xEXAMPLENFTADDRESS
 
 
-transaction(collectionGroupID: UInt64, logicalOperator: String, required: Bool, batchKey: String) {
+transaction(collectionGroupID: UInt64, logicalOperator: String, required: Bool, metadata: {String: String}) {
     let admin: &DSSCollection.Admin
 
     prepare(signer: AuthAccount) {
@@ -17,7 +17,7 @@ transaction(collectionGroupID: UInt64, logicalOperator: String, required: Bool, 
             logicalOperator: logicalOperator,
             required: required,
             typeName: typeName,
-            batchKey: batchKey
+            metadata: metadata
         )
 
         log("====================================")

--- a/dss-collection-nft/transactions/admin/create_slot.cdc
+++ b/dss-collection-nft/transactions/admin/create_slot.cdc
@@ -2,7 +2,7 @@ import DSSCollection from "../../contracts/DSSCollection.cdc"
 import ExampleNFT from 0xEXAMPLENFTADDRESS
 
 
-transaction(collectionGroupID: UInt64, logicalOperator: String, required: Bool) {
+transaction(collectionGroupID: UInt64, logicalOperator: String, required: Bool, batchKey: String) {
     let admin: &DSSCollection.Admin
 
     prepare(signer: AuthAccount) {
@@ -16,7 +16,8 @@ transaction(collectionGroupID: UInt64, logicalOperator: String, required: Bool) 
             collectionGroupID: collectionGroupID,
             logicalOperator: logicalOperator,
             required: required,
-            typeName: typeName
+            typeName: typeName,
+            batchKey: batchKey
         )
 
         log("====================================")


### PR DESCRIPTION
Added metadata as requested by collection-group team. Metadata is used to sync the on-chain and off-chain creation of a collection group and slot.