### PR TITLE
Added some helper methods for offchain ownership check/mint counts

### DIFF
--- a/dss-collection-nft/contracts/DSSCollection.cdc
+++ b/dss-collection-nft/contracts/DSSCollection.cdc
@@ -54,6 +54,12 @@ pub contract DSSCollection: NonFungibleToken {
         completionDate: UFix64,
         level: UInt8
     )
+    pub event CollectionNFTCompletedWith(
+        collectionGroupID: UInt64,
+        completionAddress: String,
+        completionNftIds: [UInt64]
+    )
+
     pub event CollectionNFTBurned(id: UInt64)
 
     // Named Paths
@@ -68,6 +74,8 @@ pub contract DSSCollection: NonFungibleToken {
     pub var totalSupply:    UInt64
     pub var collectionGroupNFTCount: {UInt64: UInt64}
 
+    // Placeholder for future updates
+    pub let extCollectionGroup: {String: AnyStruct}
 
     // Lists in contract
     //
@@ -597,6 +605,12 @@ pub contract DSSCollection: NonFungibleToken {
             } else {
                 DSSCollection.completedCollections[userAddress]!.append(collection)
             }
+
+            emit CollectionNFTCompletedWith(
+                collectionGroupID: collectionGroupID,
+                completionAddress: userAddress.toString(),
+                completionNftIds: nftIDs
+            )
         }
 
         // Borrow a Collection Group
@@ -729,6 +743,7 @@ pub contract DSSCollection: NonFungibleToken {
         self.collectionGroupByID <- {}
         self.slotByID <- {}
         self.completedCollections = {}
+        self.extCollectionGroup = {}
 
         // Create an Admin resource and save it to storage
         let admin <- create Admin()

--- a/dss-collection-nft/contracts/DSSCollection.cdc
+++ b/dss-collection-nft/contracts/DSSCollection.cdc
@@ -374,7 +374,7 @@ pub contract DSSCollection: NonFungibleToken {
         return false
     }
 
-    // Get the completed collection for a given collection group ID and address
+    // Get the nftIds for each completed collection for a given address
     //
     pub fun getCompletedCollectionIDs(address: Address): [CollectionCompletedWith]? {
         return DSSCollection.completedCollections[address]
@@ -588,10 +588,10 @@ pub contract DSSCollection: NonFungibleToken {
     // A resource that allows managing metadata and minting NFTs
     //
     pub resource Admin: NFTMinter {
-        // Complete a collection group for a given user with a list of NFT IDs
+        // Record the nftIds that were used to complete a CollectionGroup
+        //
         pub fun completedCollectionGroup(collectionGroupID: UInt64, userAddress: Address, nftIDs: [UInt64]) {
             let collection = CollectionCompletedWith(collectionGroupID: collectionGroupID, nftIDs: nftIDs)
-            // Update the completed collections mapping
             if DSSCollection.completedCollections[userAddress] == nil {
                 DSSCollection.completedCollections[userAddress] = [collection]
             } else {

--- a/dss-collection-nft/lib/go/test/dss_collection_test.go
+++ b/dss-collection-nft/lib/go/test/dss_collection_test.go
@@ -1,10 +1,11 @@
 package test
 
 import (
-	emulator "github.com/onflow/flow-emulator"
-	"github.com/stretchr/testify/assert"
 	"strconv"
 	"testing"
+
+	emulator "github.com/onflow/flow-emulator"
+	"github.com/stretchr/testify/assert"
 )
 
 // ------------------------------------------------------------
@@ -361,5 +362,195 @@ func testMintNFT(
 		assert.Contains(t, displayView.Name, strconv.Itoa(nftLevel))
 		assert.Contains(t, displayView.Description, userAddress.String())
 		assert.NotNil(t, displayView.ImageURL)
+	}
+}
+
+func TestOwnershipCheck(t *testing.T) {
+	b := newEmulator()
+	contracts := DSSCollectionDeployContracts(t, b)
+	t.Run("Should be able to determine if a account still owns the NFTs that completed a CG", func(t *testing.T) {
+		testOwnershipCheck(
+			t,
+			b,
+			contracts,
+			false,
+		)
+	})
+}
+
+func testOwnershipCheck(
+	t *testing.T,
+	b *emulator.Blockchain,
+	contracts Contracts,
+	shouldRevert bool,
+) {
+	collectionGroupName := "Top Shot All Stars"
+	collectionGroupId := createCollectionGroup(
+		t,
+		b,
+		contracts,
+		false,
+		collectionGroupName,
+		"All Stars",
+		"NBA Top Shot",
+	)
+
+	closeCollectionGroup(
+		t,
+		b,
+		contracts,
+		false,
+		collectionGroupId,
+	)
+
+	userAddress, userSigner := createAccount(t, b)
+	setupDSSCollectionAccount(t, b, userAddress, userSigner, contracts)
+	setupExampleNFT(t, b, userAddress, userSigner, contracts)
+
+	user2Address, user2Signer := createAccount(t, b)
+	setupExampleNFT(t, b, user2Address, user2Signer, contracts)
+
+	nftLevel := 5
+
+	mintNFT(
+		t,
+		b,
+		contracts,
+		false,
+		userAddress.String(),
+		collectionGroupId,
+		userAddress.String(),
+		uint8(nftLevel),
+	)
+
+	exampleNftID := mintExampleNFT(
+		t,
+		b,
+		contracts,
+		false,
+		userAddress.String(),
+	)
+
+	completedCollectionGroup(
+		t,
+		b,
+		contracts,
+		false,
+		collectionGroupId,
+		userAddress.String(),
+		[]uint64{exampleNftID},
+	)
+
+	if !shouldRevert {
+		ownershipCheck := checkCollectionOwnership(
+			t,
+			b,
+			contracts,
+			false,
+			userAddress.String(),
+			collectionGroupId,
+		)
+
+		assert.True(t, ownershipCheck)
+
+		// Transfer NFT to 0x0 address before checking ownership
+		transferNFT(
+			t,
+			b,
+			contracts,
+			false,
+			userAddress,
+			user2Signer,
+			user2Address.String(),
+			uint64(exampleNftID),
+		)
+
+		// Ownership void after NFT has been moved
+		ownershipCheck2 := checkCollectionOwnership(
+			t,
+			b,
+			contracts,
+			false,
+			userAddress.String(),
+			collectionGroupId,
+		)
+
+		assert.False(t, ownershipCheck2)
+	}
+}
+
+func TestCompletionCount(t *testing.T) {
+	b := newEmulator()
+	contracts := DSSCollectionDeployContracts(t, b)
+	t.Run("Should be able to return the number of completion NFTs minted for a given collectionId", func(t *testing.T) {
+		testCompletionCount(
+			t,
+			b,
+			contracts,
+			false,
+		)
+	})
+}
+
+func testCompletionCount(
+	t *testing.T,
+	b *emulator.Blockchain,
+	contracts Contracts,
+	shouldRevert bool,
+) {
+	collectionGroupName := "Top Shot All Stars"
+	collectionGroupId := createCollectionGroup(
+		t,
+		b,
+		contracts,
+		false,
+		collectionGroupName,
+		"All Stars",
+		"NBA Top Shot",
+	)
+
+	closeCollectionGroup(
+		t,
+		b,
+		contracts,
+		false,
+		collectionGroupId,
+	)
+
+	userAddress, userSigner := createAccount(t, b)
+	setupDSSCollectionAccount(t, b, userAddress, userSigner, contracts)
+
+	user2Address, user2Signer := createAccount(t, b)
+	setupDSSCollectionAccount(t, b, user2Address, user2Signer, contracts)
+
+	nftLevel := 5
+
+	mintNFT(
+		t,
+		b,
+		contracts,
+		false,
+		userAddress.String(),
+		collectionGroupId,
+		userAddress.String(),
+		uint8(nftLevel),
+	)
+
+	mintNFT(
+		t,
+		b,
+		contracts,
+		false,
+		userAddress.String(),
+		collectionGroupId,
+		user2Address.String(),
+		uint8(nftLevel),
+	)
+
+	if !shouldRevert {
+		expectedNFTCount := uint64(2)
+		nftCount := getCollectionGroupNFTCount(t, b, contracts, collectionGroupId)
+
+		assert.Equal(t, expectedNFTCount, nftCount)
 	}
 }

--- a/dss-collection-nft/lib/go/test/dss_collection_test.go
+++ b/dss-collection-nft/lib/go/test/dss_collection_test.go
@@ -393,6 +393,7 @@ func testOwnershipCheck(
 		collectionGroupName,
 		"All Stars",
 		"NBA Top Shot",
+		map[string]string{"key": "META"},
 	)
 
 	closeCollectionGroup(
@@ -507,6 +508,7 @@ func testCompletionCount(
 		collectionGroupName,
 		"All Stars",
 		"NBA Top Shot",
+		map[string]string{"key": "META"},
 	)
 
 	closeCollectionGroup(

--- a/dss-collection-nft/lib/go/test/scripts.go
+++ b/dss-collection-nft/lib/go/test/scripts.go
@@ -36,3 +36,36 @@ func getDSSCollectionNFTDisplayMetadataView(
 
 	return parseMetadataDisplayView(result)
 }
+
+func getCollectionGroupNFTCount(
+	t *testing.T,
+	b *emulator.Blockchain,
+	contracts Contracts,
+	collectionGroupID uint64,
+) uint64 {
+	script := getCollectionGroupNFTCountScript(contracts)
+	result := executeScriptAndCheck(t, b, script, [][]byte{
+		jsoncdc.MustEncode(cadence.UInt64(collectionGroupID)),
+	})
+
+	nftCount := result.ToGoValue().(uint64)
+	return nftCount
+}
+
+func checkCollectionOwnership(
+	t *testing.T,
+	b *emulator.Blockchain,
+	contracts Contracts,
+	isAuthorized bool,
+	userAddress string,
+	collectionGroupID uint64,
+) bool {
+	script := getCheckCollectionOwnershipScript(contracts)
+	address := flow.HexToAddress(userAddress)
+	result := executeScriptAndCheck(t, b, script, [][]byte{
+		jsoncdc.MustEncode(cadence.Address(address)),
+		jsoncdc.MustEncode(cadence.UInt64(collectionGroupID)),
+	})
+
+	return result.ToGoValue().(bool)
+}

--- a/dss-collection-nft/lib/go/test/templates.go
+++ b/dss-collection-nft/lib/go/test/templates.go
@@ -33,6 +33,8 @@ const (
 	CreateTimeBoundCollectionGroupTxPath = TransactionsRootPath + "/admin/create_collection_group_time_bound.cdc"
 	CloseCollectionGroupTxPath           = TransactionsRootPath + "/admin/close_collection_group.cdc"
 	GetCollectionGroupByIDScriptPath     = ScriptsRootPath + "/get_collection_group.cdc"
+	GetCollectionGroupNFTCountScriptPath = ScriptsRootPath + "/get_collection_group_nft_count.cdc"
+	CheckCollectionOwnershipScriptPath   = ScriptsRootPath + "/check_collection_ownership.cdc"
 
 	// Slots
 	CreateSlotTxPath       = TransactionsRootPath + "/admin/create_slot.cdc"
@@ -40,7 +42,11 @@ const (
 	CreateItemInSlotTxPath = TransactionsRootPath + "/admin/create_item_in_slot.cdc"
 
 	// NFTs
+	SetupExampleNFTxPath                 = TransactionsRootPath + "/user/setup_example_nft.cdc"
+	TransferNFTTxPath                    = TransactionsRootPath + "/user/transfer_nft.cdc"
 	MintNFTTxPath                        = TransactionsRootPath + "/admin/mint_nft.cdc"
+	MintExampleNFTTxPath                 = TransactionsRootPath + "/admin/mint_example_nft.cdc"
+	CompletedCollectionGroupTxPath       = TransactionsRootPath + "/admin/set_completed_collection_group.cdc"
 	ReadNftSupplyScriptPath              = ScriptsRootPath + "/total_supply.cdc"
 	ReadNftPropertiesTxPath              = ScriptsRootPath + "/get_nft.cdc"
 	DSSCollectionDisplayMetadataViewPath = ScriptsRootPath + "/metadata_display_view.cdc"
@@ -107,6 +113,13 @@ func setupAccountTransaction(contracts Contracts) []byte {
 	)
 }
 
+func setupExampleNFTTransaction(contracts Contracts) []byte {
+	return replaceAddresses(
+		readFile(SetupExampleNFTxPath),
+		contracts,
+	)
+}
+
 func isAccountSetupScript(contracts Contracts) []byte {
 	return replaceAddresses(
 		readFile(IsAccountSetupScriptPath),
@@ -166,9 +179,30 @@ func createItemInSlotTransaction(contracts Contracts) []byte {
 // ------------------------------------------------------------
 // DSSCollection NFTs
 // ------------------------------------------------------------
+func transferNFTTransaction(contracts Contracts) []byte {
+	return replaceAddresses(
+		readFile(TransferNFTTxPath),
+		contracts,
+	)
+}
+
+func setCompletedCollectionGroup(contracts Contracts) []byte {
+	return replaceAddresses(
+		readFile(CompletedCollectionGroupTxPath),
+		contracts,
+	)
+}
+
 func mintDSSCollectionTransaction(contracts Contracts) []byte {
 	return replaceAddresses(
 		readFile(MintNFTTxPath),
+		contracts,
+	)
+}
+
+func mintExampleNFTTransaction(contracts Contracts) []byte {
+	return replaceAddresses(
+		readFile(MintExampleNFTTxPath),
 		contracts,
 	)
 }
@@ -208,6 +242,20 @@ func LoadMetadataViews(ftAddress flow.Address, nftAddress flow.Address) []byte {
 func loadDSSCollectionDisplayMetadataViewScript(contracts Contracts) []byte {
 	return replaceAddresses(
 		readFile(DSSCollectionDisplayMetadataViewPath),
+		contracts,
+	)
+}
+
+func getCollectionGroupNFTCountScript(contracts Contracts) []byte {
+	return replaceAddresses(
+		readFile(GetCollectionGroupNFTCountScriptPath),
+		contracts,
+	)
+}
+
+func getCheckCollectionOwnershipScript(contracts Contracts) []byte {
+	return replaceAddresses(
+		readFile(CheckCollectionOwnershipScriptPath),
 		contracts,
 	)
 }

--- a/dss-collection-nft/lib/go/test/test.go
+++ b/dss-collection-nft/lib/go/test/test.go
@@ -1,10 +1,11 @@
 package test
 
 import (
-	jsoncdc "github.com/onflow/cadence/encoding/json"
-	"github.com/onflow/flow-emulator/types"
 	"io/ioutil"
 	"testing"
+
+	jsoncdc "github.com/onflow/cadence/encoding/json"
+	"github.com/onflow/flow-emulator/types"
 
 	"github.com/onflow/cadence"
 	emulator "github.com/onflow/flow-emulator"
@@ -262,6 +263,31 @@ func setupDSSCollectionAccount(
 ) {
 	tx := flow.NewTransaction().
 		SetScript(setupAccountTransaction(contracts)).
+		SetGasLimit(100).
+		SetProposalKey(b.ServiceKey().Address, b.ServiceKey().Index, b.ServiceKey().SequenceNumber).
+		SetPayer(b.ServiceKey().Address).
+		AddAuthorizer(userAddress)
+
+	signer, err := b.ServiceKey().Signer()
+	assert.NoError(t, err)
+
+	signAndSubmit(
+		t, b, tx,
+		[]flow.Address{b.ServiceKey().Address, userAddress},
+		[]crypto.Signer{signer, userSigner},
+		false,
+	)
+}
+
+func setupExampleNFT(
+	t *testing.T,
+	b *emulator.Blockchain,
+	userAddress sdk.Address,
+	userSigner crypto.Signer,
+	contracts Contracts,
+) {
+	tx := flow.NewTransaction().
+		SetScript(setupExampleNFTTransaction(contracts)).
 		SetGasLimit(100).
 		SetProposalKey(b.ServiceKey().Address, b.ServiceKey().Index, b.ServiceKey().SequenceNumber).
 		SetPayer(b.ServiceKey().Address).

--- a/dss-collection-nft/lib/go/test/types.go
+++ b/dss-collection-nft/lib/go/test/types.go
@@ -63,6 +63,7 @@ func parseSlotData(value cadence.Value) SlotData {
 		item := parseItemData(val)
 		items = append(items, item)
 	}
+
 	slotData := SlotData{
 		fields[0].ToGoValue().(uint64),
 		fields[1].ToGoValue().(uint64),

--- a/dss-collection-nft/scripts/check_collection_ownership.cdc
+++ b/dss-collection-nft/scripts/check_collection_ownership.cdc
@@ -1,0 +1,34 @@
+import NonFungibleToken from "../../contracts/NonFungibleToken.cdc"
+import ExampleNFT from 0xEXAMPLENFTADDRESS
+import DSSCollection from "../../contracts/DSSCollection.cdc"
+
+pub fun main(address: Address, collectionGroupID: UInt64): Bool {
+    let completedNFTs: [DSSCollection.CollectionCompletedWith]? = DSSCollection.getCompletedCollectionIDs(address: address)
+
+    if completedNFTs == nil {
+        return false
+    }
+    let account = getAccount(address)
+
+    let userNFTs = account
+        .getCapability(ExampleNFT.CollectionPublicPath)
+        .borrow<&{NonFungibleToken.CollectionPublic}>()
+        ?? panic("Could not borrow capability from public collection")
+
+    // Iterate over the completed NFTs and check if the user still
+    // owns them and they are of type ExampleNFT.NFT
+    for completedCollectionWith in completedNFTs! {
+        if completedCollectionWith.collectionGroupID == collectionGroupID {
+            for nftID in completedCollectionWith.nftIDs {
+                // Use getIDs to check if the nftID exists in the collection
+                let ownedNFTs = userNFTs.getIDs()
+
+                if !(ownedNFTs.contains(nftID)) {
+                    return false
+                }
+            }
+        }
+    }
+
+    return true
+}

--- a/dss-collection-nft/scripts/get_collection_group_nft_count.cdc
+++ b/dss-collection-nft/scripts/get_collection_group_nft_count.cdc
@@ -1,0 +1,6 @@
+import DSSCollection from "../../contracts/DSSCollection.cdc"
+
+pub fun main(collectionGroupId: UInt64): UInt64 {
+    let count = DSSCollection.collectionGroupNFTCount[collectionGroupId] ?? 0
+    return count
+}

--- a/dss-collection-nft/transactions/admin/mint_example_nft.cdc
+++ b/dss-collection-nft/transactions/admin/mint_example_nft.cdc
@@ -1,0 +1,41 @@
+import NonFungibleToken from "../../contracts/NonFungibleToken.cdc"
+import ExampleNFT from 0xEXAMPLENFTADDRESS
+import MetadataViews from 0xMETADATAVIEWSADDRESS
+
+transaction(recipient: Address) {
+    let minter: &ExampleNFT.NFTMinter
+    let recipientCollectionRef: &{NonFungibleToken.CollectionPublic}
+    let mintingIDBefore: UInt64
+
+    prepare(signer: AuthAccount) {
+        self.mintingIDBefore = ExampleNFT.totalSupply
+
+        self.minter = signer.borrow<&ExampleNFT.NFTMinter>(from: ExampleNFT.MinterStoragePath)
+            ?? panic("Account does not store an object at the specified path")
+
+        self.recipientCollectionRef = getAccount(recipient)
+            .getCapability(ExampleNFT.CollectionPublicPath)
+            .borrow<&{NonFungibleToken.CollectionPublic}>()
+            ?? panic("Could not get receiver reference to the NFT Collection")
+    }
+
+    execute {
+        // Stub data for other parameters
+        let name: String = "Example NFT"
+        let description: String = "This is an example NFT."
+        let thumbnail: String = "nft.jpg"
+
+        self.minter.mintNFT(
+            recipient: self.recipientCollectionRef,
+            name: name,
+            description: description,
+            thumbnail: thumbnail,
+            royalties: []
+        )
+    }
+
+    post {
+        self.recipientCollectionRef.getIDs().contains(self.mintingIDBefore): "The next NFT ID should have been minted and delivered"
+        ExampleNFT.totalSupply == self.mintingIDBefore + 1: "The total supply should have been increased by 1"
+    }
+}

--- a/dss-collection-nft/transactions/admin/set_completed_collection_group.cdc
+++ b/dss-collection-nft/transactions/admin/set_completed_collection_group.cdc
@@ -1,0 +1,33 @@
+import NonFungibleToken from "../../contracts/NonFungibleToken.cdc"
+import DSSCollection from "../../contracts/DSSCollection.cdc"
+
+transaction(collectionGroupID: UInt64, userAddress: Address, nftIDs: [UInt64]) {
+    // Local variable for the admin reference
+    let admin: &DSSCollection.Admin
+
+    prepare(signer: AuthAccount) {
+        // Borrow a reference to the Admin resource
+        self.admin = signer.borrow<&DSSCollection.Admin>(from: DSSCollection.AdminStoragePath)
+            ?? panic("Could not borrow a reference to the DSSCollection Admin capability")
+    }
+
+    execute {
+        // Call the completedCollectionGroup function using the borrowed admin reference
+        self.admin.completedCollectionGroup(
+            collectionGroupID: collectionGroupID,
+            userAddress: userAddress,
+            nftIDs: nftIDs
+        )
+
+        log("====================================")
+        log("Updated Completed Collection Group:")
+        log("CollectionID: ".concat(collectionGroupID.toString()))
+        log("UserAddress: ".concat(userAddress.toString()))
+        log("NFT IDs: [")
+        for nftID in nftIDs {
+            log("  ".concat(nftID.toString()))
+        }
+        log("]")
+        log("====================================")
+    }
+}

--- a/dss-collection-nft/transactions/user/setup_example_nft.cdc
+++ b/dss-collection-nft/transactions/user/setup_example_nft.cdc
@@ -1,0 +1,27 @@
+import NonFungibleToken from "../../contracts/NonFungibleToken.cdc"
+import ExampleNFT from 0xEXAMPLENFTADDRESS
+import MetadataViews from 0xMETADATAVIEWSADDRESS
+
+/// This transaction is what an account would run
+/// to set itself up to receive NFTs
+transaction {
+
+    prepare(signer: AuthAccount) {
+        // Return early if the account already has a collection
+        if signer.borrow<&ExampleNFT.Collection>(from: ExampleNFT.CollectionStoragePath) != nil {
+            return
+        }
+
+        // Create a new empty collection
+        let collection <- ExampleNFT.createEmptyCollection()
+
+        // save it to the account
+        signer.save(<-collection, to: ExampleNFT.CollectionStoragePath)
+
+        // create a public capability for the collection
+        signer.link<&{NonFungibleToken.CollectionPublic, ExampleNFT.ExampleNFTCollectionPublic, MetadataViews.ResolverCollection}>(
+            ExampleNFT.CollectionPublicPath,
+            target: ExampleNFT.CollectionStoragePath
+        )
+    }
+}

--- a/dss-collection-nft/transactions/user/transfer_nft.cdc
+++ b/dss-collection-nft/transactions/user/transfer_nft.cdc
@@ -1,0 +1,35 @@
+import NonFungibleToken from "../../contracts/NonFungibleToken.cdc"
+import ExampleNFT from 0xEXAMPLENFTADDRESS
+
+transaction(nftID: UInt64, to: Address) {
+  /// Reference to the withdrawer's collection
+  let withdrawRef: &ExampleNFT.Collection
+
+  /// Reference of the collection to deposit the NFT to
+  let depositRef: &{NonFungibleToken.CollectionPublic}
+
+  prepare(signer: AuthAccount) {
+    // borrow a reference to the signer's NFT collection
+    self.withdrawRef = signer
+        .borrow<&ExampleNFT.Collection>(from: ExampleNFT.CollectionStoragePath)
+        ?? panic("Account does not store an object at the specified path")
+
+    // get the recipients public account object
+    let recipient = getAccount(to)
+
+    // borrow a public reference to the receivers collection
+    self.depositRef = recipient
+        .getCapability(ExampleNFT.CollectionPublicPath)
+        .borrow<&{NonFungibleToken.CollectionPublic}>()
+        ?? panic("Could not borrow a reference to the receiver's collection")
+
+  }
+
+  execute {
+    // withdraw the NFT from the owner's collection
+    let nft <- self.withdrawRef.withdraw(withdrawID: nftID)
+
+    // Deposit the NFT in the recipient's collection
+    self.depositRef.deposit(token: <-nft)
+  }
+}


### PR DESCRIPTION
### PR - Onchain Helpers

@HouseOfHufflepuff 🙏 thanks in advance for the review


#### 1) Added check_collection_ownership.cdc script
Added a OnChain method of checking if a `flowAddress` of a `CollectionGroupId` still owns the `nftIds` that were recorded for that address when the completion token was minted.


```
pub var completedCollections: {Address: [CollectionCompletedWith]}
```

Usage:

1) When the BE goes to mint a flowAccounts CollectionGroup token, we can fire an additional transaction `transactions/admin/set_completed_collection_group.cdc` and provide the `flowAddress` and the list of `nftIds` used to validate the completion. 


2) Anyone can run the following cadence script `scripts/check_collection_ownership.cdc`, and provide `collectionGroupID`, `userAddress` and get back a boolean reflecting if all the `nftIds` are still owned by the user.

    Currently `nftType` isn't stored on this struct, it's assumed whoever is calling this script would know the `nftType` that belongs to the provided `collectionGroupId`.



#### 2) Added get_collection_group_nft_count.cdc script

```
pub var collectionGroupNFTCount: {UInt64: UInt64}
```

Added a OnChain method of checking how many completed tokens for a given `collectionGroupID` have been minted. 





