### PR TITLE
Extend Lock & Swap Lock

### DIFF
--- a/locked-nft/contracts/NFTLocker.cdc
+++ b/locked-nft/contracts/NFTLocker.cdc
@@ -26,6 +26,7 @@ pub contract NFTLocker {
     )
     pub event NFTLockExtended(
         id: UInt64,
+        lockedAt: UInt64,
         lockedUntil: UInt64,
         extendedDuration: UInt64,
         nftType: Type
@@ -184,8 +185,13 @@ pub contract NFTLocker {
             let lockedToken = (NFTLocker.lockedTokens[nftType]!)[id]!
             lockedToken.extendLock(extendedDuration: extendedDuration)
 
+            let nestedLock = NFTLocker.lockedTokens[nftType]!
+            nestedLock[id] = lockedToken
+            NFTLocker.lockedTokens[nftType] = nestedLock
+
             emit NFTLockExtended(
                 id: id,
+                lockedAt: lockedToken.lockedAt,
                 lockedUntil: lockedToken.lockedUntil,
                 extendedDuration: extendedDuration,
                 nftType: nftType

--- a/locked-nft/contracts/NFTLocker.cdc
+++ b/locked-nft/contracts/NFTLocker.cdc
@@ -74,10 +74,6 @@ pub contract NFTLocker {
         }
 
         pub fun extendLock(extendedDuration: UInt64) {
-            pre {
-                self.lockedUntil != 0: "nft not locked"
-            }
-
             self.lockedUntil = self.lockedUntil + extendedDuration
         }
     }
@@ -93,6 +89,14 @@ pub contract NFTLocker {
             if lockedToken.lockedUntil < UInt64(getCurrentBlock().timestamp) {
                 return true
             }
+        }
+
+        return false
+    }
+
+    pub fun nftIsLocked(id: UInt64, nftType: Type): Bool {
+        if let lockedToken = (NFTLocker.lockedTokens[nftType]!)[id] {
+            return true
         }
 
         return false
@@ -190,6 +194,13 @@ pub contract NFTLocker {
         }
 
         pub fun extendLock(id: UInt64, nftType: Type, extendedDuration: UInt64) {
+            pre {
+                NFTLocker.nftIsLocked(
+                    id: id,
+                    nftType: nftType
+                ) == true : "token is not locked"
+            }
+
             let lockedToken = (NFTLocker.lockedTokens[nftType]!)[id]!
             lockedToken.extendLock(extendedDuration: extendedDuration)
 

--- a/locked-nft/contracts/NFTLocker.cdc
+++ b/locked-nft/contracts/NFTLocker.cdc
@@ -53,24 +53,31 @@ pub contract NFTLocker {
         pub let lockedAt: UInt64
         pub var lockedUntil: UInt64
         pub let nftType: Type
+        pub let extension: {String: AnyStruct}
 
-        init (id: UInt64, owner: Address, duration: UInt64, nftType: Type) {
+        init (id: UInt64, owner: Address, duration: UInt64, nftType: Type, extension: {String: AnyStruct}) {
             if let lockedToken = (NFTLocker.lockedTokens[nftType]!)[id] {
                 self.id = id
                 self.owner = lockedToken.owner
                 self.lockedAt = lockedToken.lockedAt
                 self.lockedUntil = lockedToken.lockedUntil
                 self.nftType = lockedToken.nftType
+                self.extension = lockedToken.extension
             } else {
                 self.id = id
                 self.owner = owner
                 self.lockedAt = UInt64(getCurrentBlock().timestamp)
                 self.lockedUntil = self.lockedAt + duration
                 self.nftType = nftType
+                self.extension = extension
             }
         }
 
         pub fun extendLock(extendedDuration: UInt64) {
+            pre {
+                self.lockedUntil != 0: "nft not locked"
+            }
+
             self.lockedUntil = self.lockedUntil + extendedDuration
         }
     }
@@ -160,7 +167,8 @@ pub contract NFTLocker {
                 id: id,
                 owner: self.owner!.address,
                 duration: duration,
-                nftType: nftType
+                nftType: nftType,
+                extension: {}
             )
             nestedLock[id] = lockedData
             NFTLocker.lockedTokens[nftType] = nestedLock

--- a/locked-nft/contracts/NFTLocker.cdc
+++ b/locked-nft/contracts/NFTLocker.cdc
@@ -126,6 +126,10 @@ pub contract NFTLocker {
         ///
         pub fun unlock(id: UInt64, nftType: Type): @NonFungibleToken.NFT {
             pre {
+                NFTLocker.nftIsLocked(
+                    id: id,
+                    nftType: nftType
+                ) == true : "token is not locked"
                 NFTLocker.canUnlockToken(
                     id: id,
                     nftType: nftType
@@ -134,8 +138,9 @@ pub contract NFTLocker {
 
             let token <- self.lockedNFTs[nftType]?.remove(key: id)!!
 
-            if let lockedToken = NFTLocker.lockedTokens[nftType] {
-                lockedToken.remove(key: id)
+            if let lockedType = NFTLocker.lockedTokens[nftType] {
+                lockedType.remove(key: id)
+                NFTLocker.lockedTokens[nftType] = lockedType
             }
             NFTLocker.totalLockedTokens = NFTLocker.totalLockedTokens - 1
 

--- a/locked-nft/lib/go/test/lockednft_test.go
+++ b/locked-nft/lib/go/test/lockednft_test.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"fmt"
 	emulator "github.com/onflow/flow-emulator"
 	"github.com/stretchr/testify/assert"
 	"testing"
@@ -246,4 +247,79 @@ func testUnlockNFT(
 		userSigner,
 		exampleNftID,
 	)
+}
+
+func TestExtendLock(t *testing.T) {
+	b := newEmulator()
+	contracts := NFTLockerDeployContracts(t, b)
+	t.Run("Should be able to extend the lock of an NFT", func(t *testing.T) {
+		testExtendLock(
+			t,
+			b,
+			contracts,
+			false,
+		)
+	})
+}
+
+func testExtendLock(
+	t *testing.T,
+	b *emulator.Blockchain,
+	contracts Contracts,
+	shouldRevert bool,
+) {
+	var duration uint64 = 10
+	var extendedDuration uint64 = 1000
+	userAddress, userSigner := createAccount(t, b)
+	setupNFTLockerAccount(t, b, userAddress, userSigner, contracts)
+	setupExampleNFT(t, b, userAddress, userSigner, contracts)
+
+	exampleNftID := mintExampleNFT(
+		t,
+		b,
+		contracts,
+		false,
+		userAddress.String(),
+	)
+
+	lockedAt, lockedUntil := lockNFT(
+		t,
+		b,
+		contracts,
+		false,
+		userAddress,
+		userSigner,
+		exampleNftID,
+		duration,
+	)
+
+	assert.Equal(t, lockedAt+duration, lockedUntil)
+
+	lockedData := getLockedTokenData(
+		t,
+		b,
+		contracts,
+		exampleNftID,
+	)
+
+	extendLock(
+		t,
+		b,
+		contracts,
+		false,
+		userAddress,
+		userSigner,
+		exampleNftID,
+		extendedDuration,
+	)
+
+	lockedData = getLockedTokenData(
+		t,
+		b,
+		contracts,
+		exampleNftID,
+	)
+
+	fmt.Println("blah")
+	fmt.Println(lockedData)
 }

--- a/locked-nft/lib/go/test/lockednft_test.go
+++ b/locked-nft/lib/go/test/lockednft_test.go
@@ -323,6 +323,50 @@ func testExtendLock(
 	assert.Less(t, lockedDataPre.LockedUntil, lockedDataPost.LockedUntil)
 }
 
+func TestExtendLockFail(t *testing.T) {
+	b := newEmulator()
+	contracts := NFTLockerDeployContracts(t, b)
+	t.Run("Should fail to extend the lock of an NFT that has not been locked", func(t *testing.T) {
+		testExtendLockFail(
+			t,
+			b,
+			contracts,
+			true,
+		)
+	})
+}
+
+func testExtendLockFail(
+	t *testing.T,
+	b *emulator.Blockchain,
+	contracts Contracts,
+	shouldRevert bool,
+) {
+	var extendedDuration uint64 = 1000
+	userAddress, userSigner := createAccount(t, b)
+	setupNFTLockerAccount(t, b, userAddress, userSigner, contracts)
+	setupExampleNFT(t, b, userAddress, userSigner, contracts)
+
+	exampleNftID := mintExampleNFT(
+		t,
+		b,
+		contracts,
+		false,
+		userAddress.String(),
+	)
+
+	extendLock(
+		t,
+		b,
+		contracts,
+		shouldRevert,
+		userAddress,
+		userSigner,
+		exampleNftID,
+		extendedDuration,
+	)
+}
+
 func TestSwapLock(t *testing.T) {
 	b := newEmulator()
 	contracts := NFTLockerDeployContracts(t, b)

--- a/locked-nft/lib/go/test/lockednft_test.go
+++ b/locked-nft/lib/go/test/lockednft_test.go
@@ -1,7 +1,6 @@
 package test
 
 import (
-	"fmt"
 	emulator "github.com/onflow/flow-emulator"
 	"github.com/stretchr/testify/assert"
 	"testing"
@@ -295,7 +294,7 @@ func testExtendLock(
 
 	assert.Equal(t, lockedAt+duration, lockedUntil)
 
-	lockedData := getLockedTokenData(
+	lockedDataPre := getLockedTokenData(
 		t,
 		b,
 		contracts,
@@ -313,13 +312,13 @@ func testExtendLock(
 		extendedDuration,
 	)
 
-	lockedData = getLockedTokenData(
+	lockedDataPost := getLockedTokenData(
 		t,
 		b,
 		contracts,
 		exampleNftID,
 	)
 
-	fmt.Println("blah")
-	fmt.Println(lockedData)
+	assert.Equal(t, lockedAt+duration+extendedDuration, lockedDataPost.LockedUntil)
+	assert.Less(t, lockedDataPre.LockedUntil, lockedDataPost.LockedUntil)
 }

--- a/locked-nft/lib/go/test/scripts.go
+++ b/locked-nft/lib/go/test/scripts.go
@@ -27,3 +27,15 @@ func readLockedTokenByIDScript(contracts Contracts) []byte {
 		contracts,
 	)
 }
+
+func getLockedTokenData(
+	t *testing.T,
+	b *emulator.Blockchain,
+	contracts Contracts,
+	id uint64,
+) LockedData {
+	script := readLockedTokenByIDScript(contracts)
+	result := executeScriptAndCheck(t, b, script, [][]byte{jsoncdc.MustEncode(cadence.UInt64(id))})
+
+	return parseLockedData(result)
+}

--- a/locked-nft/lib/go/test/scripts.go
+++ b/locked-nft/lib/go/test/scripts.go
@@ -28,6 +28,13 @@ func readLockedTokenByIDScript(contracts Contracts) []byte {
 	)
 }
 
+func readInventoryScript(contracts Contracts) []byte {
+	return replaceAddresses(
+		readFile(GetInventoryScriptPath),
+		contracts,
+	)
+}
+
 func getLockedTokenData(
 	t *testing.T,
 	b *emulator.Blockchain,
@@ -38,4 +45,21 @@ func getLockedTokenData(
 	result := executeScriptAndCheck(t, b, script, [][]byte{jsoncdc.MustEncode(cadence.UInt64(id))})
 
 	return parseLockedData(result)
+}
+
+func getNFTInventory(
+	t *testing.T,
+	b *emulator.Blockchain,
+	contracts Contracts,
+	userAddress flow.Address,
+) []uint64 {
+	script := readInventoryScript(contracts)
+	result := executeScriptAndCheck(t, b, script, [][]byte{jsoncdc.MustEncode(cadence.NewAddress(userAddress))})
+	var nftIds []uint64
+	for _, val := range result.(cadence.Array).Values {
+		nftId := val.ToGoValue().(uint64)
+		nftIds = append(nftIds, nftId)
+	}
+
+	return nftIds
 }

--- a/locked-nft/lib/go/test/templates.go
+++ b/locked-nft/lib/go/test/templates.go
@@ -9,8 +9,6 @@ import (
 	"github.com/onflow/flow-go-sdk"
 )
 
-// Handle relative paths by making these regular expressions
-
 const (
 	nftAddressPlaceholder           = "\"[^\"]*NonFungibleToken.cdc\""
 	NFTLockerAddressPlaceholder     = "\"[^\"]*NFTLocker.cdc\""
@@ -40,8 +38,10 @@ const (
 
 	// NFTLocker
 	GetLockedTokenByIDScriptPath = ScriptsRootPath + "/get_locked_token.cdc"
+	GetInventoryScriptPath       = ScriptsRootPath + "/examplenft/inventory.cdc"
 	LockNFTTxPath                = TransactionsRootPath + "/lock_nft.cdc"
 	ExtendLockTxPath             = TransactionsRootPath + "/extend_lock.cdc"
+	SwapLockTxPath               = TransactionsRootPath + "/swap_lock.cdc"
 	UnlockNFTTxPath              = TransactionsRootPath + "/unlock_nft.cdc"
 )
 
@@ -131,6 +131,13 @@ func lockNFTTransaction(contracts Contracts) []byte {
 func extendLockTransaction(contracts Contracts) []byte {
 	return replaceAddresses(
 		readFile(ExtendLockTxPath),
+		contracts,
+	)
+}
+
+func swapLockTransaction(contracts Contracts) []byte {
+	return replaceAddresses(
+		readFile(SwapLockTxPath),
 		contracts,
 	)
 }

--- a/locked-nft/lib/go/test/templates.go
+++ b/locked-nft/lib/go/test/templates.go
@@ -41,6 +41,7 @@ const (
 	// NFTLocker
 	GetLockedTokenByIDScriptPath = ScriptsRootPath + "/get_locked_token.cdc"
 	LockNFTTxPath                = TransactionsRootPath + "/lock_nft.cdc"
+	ExtendLockTxPath             = TransactionsRootPath + "/extend_lock.cdc"
 	UnlockNFTTxPath              = TransactionsRootPath + "/unlock_nft.cdc"
 )
 
@@ -123,6 +124,13 @@ func mintExampleNFTTransaction(contracts Contracts) []byte {
 func lockNFTTransaction(contracts Contracts) []byte {
 	return replaceAddresses(
 		readFile(LockNFTTxPath),
+		contracts,
+	)
+}
+
+func extendLockTransaction(contracts Contracts) []byte {
+	return replaceAddresses(
+		readFile(ExtendLockTxPath),
 		contracts,
 	)
 }

--- a/locked-nft/lib/go/test/test.go
+++ b/locked-nft/lib/go/test/test.go
@@ -4,7 +4,6 @@ import (
 	"io/ioutil"
 	"testing"
 
-	jsoncdc "github.com/onflow/cadence/encoding/json"
 	"github.com/onflow/flow-emulator/types"
 
 	"github.com/onflow/cadence"
@@ -302,16 +301,4 @@ func setupExampleNFT(
 		[]crypto.Signer{signer, userSigner},
 		false,
 	)
-}
-
-func getLockedTokenData(
-	t *testing.T,
-	b *emulator.Blockchain,
-	contracts Contracts,
-	id uint64,
-) LockedData {
-	script := readLockedTokenByIDScript(contracts)
-	result := executeScriptAndCheck(t, b, script, [][]byte{jsoncdc.MustEncode(cadence.UInt64(id))})
-
-	return parseLockedData(result)
 }

--- a/locked-nft/lib/go/test/transactions.go
+++ b/locked-nft/lib/go/test/transactions.go
@@ -136,3 +136,32 @@ func unlockNFT(
 	)
 	fmt.Println(txResult)
 }
+
+func extendLock(
+	t *testing.T,
+	b *emulator.Blockchain,
+	contracts Contracts,
+	shouldRevert bool,
+	userAddress flow.Address,
+	userSigner crypto.Signer,
+	nftId uint64,
+	extendedDuration uint64,
+) {
+	tx := flow.NewTransaction().
+		SetScript(extendLockTransaction(contracts)).
+		SetGasLimit(100).
+		SetProposalKey(b.ServiceKey().Address, b.ServiceKey().Index, b.ServiceKey().SequenceNumber).
+		SetPayer(b.ServiceKey().Address).
+		AddAuthorizer(userAddress)
+	tx.AddArgument(cadence.UInt64(nftId))
+	tx.AddArgument(cadence.UInt64(extendedDuration))
+
+	signer, _ := b.ServiceKey().Signer()
+	txResult := signAndSubmit(
+		t, b, tx,
+		[]flow.Address{b.ServiceKey().Address, userAddress},
+		[]crypto.Signer{signer, userSigner},
+		shouldRevert,
+	)
+	fmt.Println(txResult)
+}

--- a/locked-nft/lib/go/test/transactions.go
+++ b/locked-nft/lib/go/test/transactions.go
@@ -165,3 +165,34 @@ func extendLock(
 	)
 	fmt.Println(txResult)
 }
+
+func swapLock(
+	t *testing.T,
+	b *emulator.Blockchain,
+	contracts Contracts,
+	shouldRevert bool,
+	userAddress flow.Address,
+	userSigner crypto.Signer,
+	nftLockedID uint64,
+	nftToLockID uint64,
+	duration uint64,
+) {
+	tx := flow.NewTransaction().
+		SetScript(swapLockTransaction(contracts)).
+		SetGasLimit(100).
+		SetProposalKey(b.ServiceKey().Address, b.ServiceKey().Index, b.ServiceKey().SequenceNumber).
+		SetPayer(b.ServiceKey().Address).
+		AddAuthorizer(userAddress)
+	tx.AddArgument(cadence.UInt64(nftLockedID))
+	tx.AddArgument(cadence.UInt64(nftToLockID))
+	tx.AddArgument(cadence.UInt64(duration))
+
+	signer, _ := b.ServiceKey().Signer()
+	txResult := signAndSubmit(
+		t, b, tx,
+		[]flow.Address{b.ServiceKey().Address, userAddress},
+		[]crypto.Signer{signer, userSigner},
+		shouldRevert,
+	)
+	fmt.Println(txResult)
+}

--- a/locked-nft/lib/go/test/types.go
+++ b/locked-nft/lib/go/test/types.go
@@ -5,18 +5,16 @@ import (
 )
 
 type LockedData struct {
-	Owner       string
+	Id          uint64
 	LockedAt    uint64
 	LockedUntil uint64
-	nftType     string
 }
 
 func parseLockedData(value cadence.Value) LockedData {
 	fields := value.(cadence.Struct).Fields
 	return LockedData{
-		fields[0].ToGoValue().(string),
-		fields[1].ToGoValue().(uint64),
+		fields[0].ToGoValue().(uint64),
 		fields[2].ToGoValue().(uint64),
-		fields[3].ToGoValue().(string),
+		fields[3].ToGoValue().(uint64),
 	}
 }

--- a/locked-nft/scripts/examplenft/inventory.cdc
+++ b/locked-nft/scripts/examplenft/inventory.cdc
@@ -1,5 +1,5 @@
-import NonFungibleToken from "../..contracts/NonFungibleToken.cdc"
-import ExampleNFT from "../../contracts/ExampleNFT.cdc"
+import ExampleNFT from 0xEXAMPLENFTADDRESS
+import NonFungibleToken from "../contracts/NonFungibleToken.cdc"
 
 pub fun main(acctAddress: Address): [UInt64] {
     let nftOwner = getAccount(acctAddress);

--- a/locked-nft/scripts/get_locked_token.cdc
+++ b/locked-nft/scripts/get_locked_token.cdc
@@ -1,5 +1,6 @@
 import NFTLocker from "../contracts/NFTLocker.cdc"
+import ExampleNFT from 0xEXAMPLENFTADDRESS
 
-pub fun main(id: UInt64, nftType: Type): NFTLocker.LockedData? {
-    return NFTLocker.getNFTLockerDetails(id: id, nftType: nftType)
+pub fun main(id: UInt64): NFTLocker.LockedData {
+    return NFTLocker.getNFTLockerDetails(id: id, nftType: Type<@ExampleNFT.NFT>())!
 }

--- a/locked-nft/scripts/inventory.cdc
+++ b/locked-nft/scripts/inventory.cdc
@@ -1,4 +1,5 @@
 import NFTLocker from "../contracts/NFTLocker.cdc"
+import NonFungibleToken from "../contracts/NonFungibleToken.cdc"
 
 pub fun main(acctAddress: Address): [UInt64] {
     let nftOwner = getAccount(acctAddress);

--- a/locked-nft/transactions/extend_lock.cdc
+++ b/locked-nft/transactions/extend_lock.cdc
@@ -1,0 +1,17 @@
+import NFTLocker from "../contracts/NFTLocker.cdc"
+import ExampleNFT from 0xEXAMPLENFTADDRESS
+
+
+transaction(id: UInt64, extendedDuration: UInt64) {
+    let lockRef: &NFTLocker.Collection
+
+    prepare(signer: AuthAccount) {
+        self.lockRef = signer
+            .borrow<&NFTLocker.Collection>(from: NFTLocker.CollectionStoragePath)
+            ?? panic("Account does not store an object at the specified path")
+    }
+
+    execute {
+            self.lockRef.extendLock(id: id, nftType: Type<@ExampleNFT.NFT>(), extendedDuration: extendedDuration)
+    }
+}

--- a/locked-nft/transactions/swap_lock.cdc
+++ b/locked-nft/transactions/swap_lock.cdc
@@ -1,0 +1,23 @@
+import NonFungibleToken from "../contracts/NonFungibleToken.cdc"
+import NFTLocker from "../contracts/NFTLocker.cdc"
+import ExampleNFT from 0xEXAMPLENFTADDRESS
+
+
+transaction(nftLockedID: UInt64, nftToLockID: UInt64, duration: UInt64) {
+    let exampleCollectionRef: &ExampleNFT.Collection
+    let lockRef: &NFTLocker.Collection
+
+    prepare(signer: AuthAccount) {
+        self.exampleCollectionRef = signer
+            .borrow<&ExampleNFT.Collection>(from: ExampleNFT.CollectionStoragePath)
+            ?? panic("Could not borrow a reference to the owner's collection")
+        self.lockRef = signer
+            .borrow<&NFTLocker.Collection>(from: NFTLocker.CollectionStoragePath)
+            ?? panic("Account does not store an object at the specified path")
+    }
+
+    execute {
+            self.exampleCollectionRef.deposit(token: <- self.lockRef.unlock(id: nftLockedID, nftType: Type<@ExampleNFT.NFT>()))
+            self.lockRef.lock(token: <- self.exampleCollectionRef.withdraw(withdrawID: nftToLockID), duration: duration)
+    }
+}


### PR DESCRIPTION
- Added function to extend the lock of an NFT. This will be used when we mint sticker book tokens.
- Added tx and tests to swap a lock. This will be used to upgrade elements of the sticker book.
- Removed duration from data structure as it can be derived.