### PR TITLE
align la liga traits with all day traits generation

### DIFF
--- a/sport-moment-nft/contracts/Golazos.cdc
+++ b/sport-moment-nft/contracts/Golazos.cdc
@@ -680,9 +680,7 @@ pub contract Golazos: NonFungibleToken {
                         })
                     )
                 case Type<MetadataViews.Traits>():
-                    let editiondata = Golazos.getEditionData(id: self.editionID)!
-                    let playdata = Golazos.getPlayData(id: editiondata.playID)!
-                    return MetadataViews.dictToTraits(dict: playdata.metadata, excludedNames: nil)
+                    return MetadataViews.dictToTraits(dict: self.getTraits())
 
                 case Type<MetadataViews.ExternalURL>():
                     return MetadataViews.ExternalURL("https://laligagolazos.com/moments/".concat(self.id.toString()))
@@ -781,6 +779,28 @@ pub contract Golazos: NonFungibleToken {
             }
 
             return nil
+        }
+
+        pub fun getTraits() : {String: AnyStruct} {
+            let edition: EditionData = Golazos.getEditionData(id: self.editionID)
+            let play: PlayData = Golazos.getPlayData(id: edition.playID)
+            let series: SeriesData = Golazos.getSeriesData(id: edition.seriesID)
+            let set: SetData = Golazos.getSetData(id: edition.setID)
+
+            let traitDictionary: {String: AnyStruct} = {
+                "editionTier": edition.tier,
+                "seriesName": series.name,
+                "setName": set.name,
+                "serialNumber": self.serialNumber
+            }
+
+            for name in play.metadata.keys {
+                let value = play.metadata[name] ?? ""
+                if value != "" {
+                    traitDictionary.insert(key: name, value)
+                }
+            }
+            return traitDictionary
         }
     }
 


### PR DESCRIPTION
La Liga doesn't publish Tier and some other fields as traits. Because of that, platforms like Flowty cannot filter by rarity since we pull data from the Traits Metadata standard to build out our filtering. This change alters trait generation for La Liga NFTs to operate the same way All Day does [here](https://contractbrowser.com/A.e4cf4bdc1751c65d.AllDay#L770)

I wasn't sure how to actually run tests for this, happy to do so if there are instructions