### PR TITLE
Add Admin resource

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*.cdc @dapperlabs/flow-smart-contracts @dapperlabs/studio-platform
+*.cdc @dapperlabs/studio-platform

--- a/locked-nft/contracts/NFTLocker.cdc
+++ b/locked-nft/contracts/NFTLocker.cdc
@@ -91,8 +91,6 @@ pub contract NFTLocker {
                 }
             }
         }
-
-
         return false
     }
 
@@ -111,8 +109,6 @@ pub contract NFTLocker {
                     if let unlockedTokens = &NFTLocker.adminUnlockedTokens[nftType] as &{UInt64: Bool}? {
                         unlockedTokens[id] = true
                     }
-
-
                 }
             }
         }

--- a/locked-nft/contracts/NFTLocker.cdc
+++ b/locked-nft/contracts/NFTLocker.cdc
@@ -37,6 +37,7 @@ pub contract NFTLocker {
     /// Metadata Dictionaries
     ///
     access(self) let lockedTokens:  {Type: {UInt64: LockedData}}
+    access(self) var adminUnlockedTokens:  {Type: {UInt64: Bool}}
 
     /// Data describing characteristics of the locked NFT
     ///
@@ -77,14 +78,46 @@ pub contract NFTLocker {
     /// Determine if NFT can be unlocked
     ///
     pub fun canUnlockToken(id: UInt64, nftType: Type): Bool {
-        if let lockedToken = (NFTLocker.lockedTokens[nftType]!)[id] {
-            if lockedToken.lockedUntil < UInt64(getCurrentBlock().timestamp) {
+        if let unlockedTokens = NFTLocker.adminUnlockedTokens[nftType]{
+            if unlockedTokens.containsKey(id) {
                 return true
             }
         }
 
+        if let lockedTokens = NFTLocker.lockedTokens[nftType]{
+            if let lockedToken = lockedTokens[id] {
+                if lockedToken.lockedUntil < UInt64(getCurrentBlock().timestamp) {
+                    return true
+                }
+            }
+        }
+
+
         return false
     }
+
+    /// The path to the NFTLocker Admin resource belonging to the Account
+    // which the contract is deployed on
+    pub fun GetAdminStoragePath() : StoragePath { return /storage/NFTLockerAdmin}
+
+    /// Admin resource
+    pub resource Admin {
+        pub fun expireLock(id: UInt64, nftType: Type) {
+            if let locker = &NFTLocker.lockedTokens[nftType] as &{UInt64: NFTLocker.LockedData}?{
+                if locker[id] != nil {
+                    if NFTLocker.adminUnlockedTokens[nftType] == nil {
+                        NFTLocker.adminUnlockedTokens[nftType] = {}
+                    }
+                    if let unlockedTokens = &NFTLocker.adminUnlockedTokens[nftType] as &{UInt64: Bool}? {
+                        unlockedTokens[id] = true
+                    }
+
+
+                }
+            }
+        }
+    }
+
 
     /// A public collection interface that returns the ids
     /// of nft locked for a given type
@@ -119,6 +152,11 @@ pub contract NFTLocker {
 
             if let lockedToken = NFTLocker.lockedTokens[nftType] {
                 lockedToken.remove(key: id)
+            }
+            if let unlockedTokens = &NFTLocker.adminUnlockedTokens[nftType] as &{UInt64: Bool}? {
+                if unlockedTokens.containsKey(id) {
+                    unlockedTokens.remove(key: id)
+                }
             }
             NFTLocker.totalLockedTokens = NFTLocker.totalLockedTokens - 1
 
@@ -195,7 +233,12 @@ pub contract NFTLocker {
         self.CollectionStoragePath = /storage/NFTLockerCollection
         self.CollectionPublicPath = /public/NFTLockerCollection
 
+        // Create an admin resource
+        let admin <- create Admin()
+        self.account.save(<-admin, to: NFTLocker.GetAdminStoragePath())
+
         self.totalLockedTokens = 0
         self.lockedTokens = {}
+        self.adminUnlockedTokens = {}
     }
 }

--- a/locked-nft/lib/go/test/lockednft_test.go
+++ b/locked-nft/lib/go/test/lockednft_test.go
@@ -323,7 +323,7 @@ func TestAdminUnLockNFT(t *testing.T) {
 			false,
 		)
 	})
-	//t.Run("t
+	
 	t.Run("Should fail unlocking an nft", func(t *testing.T) {
 		unlockNFT(t, b, contracts, true, userAddress, userSigner, mintedNft1)
 	})

--- a/locked-nft/lib/go/test/lockednft_test.go
+++ b/locked-nft/lib/go/test/lockednft_test.go
@@ -292,3 +292,46 @@ func testUnlockNFT(
 		exampleNftID,
 	)
 }
+
+func TestAdminUnLockNFT(t *testing.T) {
+	b := newEmulator()
+	contracts := NFTLockerDeployContracts(t, b)
+	var (
+		mintedNft1  uint64
+		userAddress flow.Address
+		userSigner  crypto.Signer
+	)
+	t.Run("Should be able to mint and lock an nft", func(t *testing.T) {
+		userAddress, userSigner = createAccount(t, b)
+		setupNFTLockerAccount(t, b, userAddress, userSigner, contracts)
+		setupExampleNFT(t, b, userAddress, userSigner, contracts)
+		exampleNftID1 := mintExampleNFT(
+			t,
+			b,
+			contracts,
+			false,
+			userAddress.String(),
+		)
+		mintedNft1 = exampleNftID1
+		testLockNFT(
+			t,
+			b,
+			contracts,
+			userAddress,
+			userSigner,
+			exampleNftID1,
+			false,
+		)
+	})
+	//t.Run("t
+	t.Run("Should fail unlocking an nft", func(t *testing.T) {
+		unlockNFT(t, b, contracts, true, userAddress, userSigner, mintedNft1)
+	})
+
+	t.Run("Should be able to admin unlock an nft", func(t *testing.T) {
+		adminUnlockNFT(t, b, contracts, false, mintedNft1)
+		// unlocking now should pass
+		unlockNFT(t, b, contracts, false, userAddress, userSigner, mintedNft1)
+	})
+
+}

--- a/locked-nft/lib/go/test/templates.go
+++ b/locked-nft/lib/go/test/templates.go
@@ -20,6 +20,7 @@ const (
 
 const (
 	NFTLockerPath        = "../../../contracts/NFTLocker.cdc"
+	NFTLockerV2Path      = "../../../contracts/NFTLockerNew.cdc"
 	ExampleNFTPath       = "../../../contracts/ExampleNFT.cdc"
 	TransactionsRootPath = "../../../transactions"
 	ScriptsRootPath      = "../../../scripts"
@@ -43,6 +44,7 @@ const (
 	GetInventoryScriptPath       = ScriptsRootPath + "/inventory.cdc"
 	LockNFTTxPath                = TransactionsRootPath + "/lock_nft.cdc"
 	UnlockNFTTxPath              = TransactionsRootPath + "/unlock_nft.cdc"
+	AdminUnlockNFTTxPath         = TransactionsRootPath + "/admin_unlock_nft.cdc"
 )
 
 // ------------------------------------------------------------
@@ -131,6 +133,13 @@ func lockNFTTransaction(contracts Contracts) []byte {
 func unlockNFTTransaction(contracts Contracts) []byte {
 	return replaceAddresses(
 		readFile(UnlockNFTTxPath),
+		contracts,
+	)
+}
+
+func adminUnlockNFTTransaction(contracts Contracts) []byte {
+	return replaceAddresses(
+		readFile(AdminUnlockNFTTxPath),
 		contracts,
 	)
 }

--- a/locked-nft/lib/go/test/transactions.go
+++ b/locked-nft/lib/go/test/transactions.go
@@ -136,3 +136,27 @@ func unlockNFT(
 	)
 	fmt.Println(txResult)
 }
+
+func adminUnlockNFT(
+	t *testing.T,
+	b *emulator.Blockchain,
+	contracts Contracts,
+	shouldRevert bool,
+	nftId uint64,
+) {
+	tx := flow.NewTransaction().
+		SetScript(adminUnlockNFTTransaction(contracts)).
+		SetGasLimit(100).
+		SetProposalKey(b.ServiceKey().Address, b.ServiceKey().Index, b.ServiceKey().SequenceNumber).
+		SetPayer(b.ServiceKey().Address).
+		AddAuthorizer(contracts.NFTLockerAddress)
+	tx.AddArgument(cadence.UInt64(nftId))
+
+	signer, _ := b.ServiceKey().Signer()
+	signAndSubmit(
+		t, b, tx,
+		[]flow.Address{b.ServiceKey().Address, contracts.NFTLockerAddress},
+		[]crypto.Signer{signer, contracts.NFTLockerSigner},
+		shouldRevert,
+	)
+}

--- a/locked-nft/transactions/admin_unlock_nft.cdc
+++ b/locked-nft/transactions/admin_unlock_nft.cdc
@@ -1,0 +1,16 @@
+import NFTLocker from "../contracts/NFTLocker.cdc"
+import ExampleNFT from 0xEXAMPLENFTADDRESS
+
+transaction(id: UInt64) {
+    let adminRef: &NFTLocker.Admin
+
+    prepare(signer: AuthAccount) {
+        self.adminRef = signer
+            .borrow<&NFTLocker.Admin>(from: NFTLocker.GetAdminStoragePath())
+            ?? panic("Could not borrow a reference to the owner's collection")
+    }
+
+    execute {
+        self.adminRef.expireLock(id: id, nftType: Type<@ExampleNFT.NFT>())
+    }
+}

--- a/locked-nft/transactions/setup_admin.cdc
+++ b/locked-nft/transactions/setup_admin.cdc
@@ -1,0 +1,12 @@
+import NFTLocker from "../contracts/NFTLocker.cdc"
+
+transaction() {
+
+    prepare(signer: AuthAccount) {
+        NFTLocker.createAndSaveAdmin(acct: signer)
+    }
+
+    execute {
+        log("NFTLocker Admin Account Created and Stored in the NFTLocker Admin Storage.")
+    }
+}


### PR DESCRIPTION
This adds an admin resource to the NFTLocker contract. This admin resource can be used to expire a lock before the expiry.

Fully aware that the init function only runs on contract deploy and i have a workaround for setting up the existing contract with the admin resource. By adding the function below to the contract and deploy temporarily while i run a transaction to call that function hence setting up the account with the Admin resource.
```cadence
pub fun createAndSaveAdmin(acct: AuthAccount) {
        pre {
            acct.borrow<&NFTLocker.Admin>(from: NFTLocker.GetAdminStoragePath()) == nil : "Admin already exists"
            acct.address == self.account.address: "Can only be called by the contract account"
        }
        let admin <- create Admin()
        acct.save(<-admin, to: NFTLocker.GetAdminStoragePath())
        self.adminUnlockedTokens = {}
}
```
The function is safe as it will only save the admin resource if this is the same account the contract is deployed to